### PR TITLE
Anders fix dec jog

### DIFF
--- a/devEcmcSup/motion/ecmcAxisBase.cpp
+++ b/devEcmcSup/motion/ecmcAxisBase.cpp
@@ -1394,7 +1394,7 @@ int ecmcAxisBase::moveVelocity(
 
   getSeq()->setTargetVel(velocitySet);
   getTraj()->setAcc(accelerationSet);
-  getTraj()->setAcc(decelerationSet);
+  getTraj()->setDec(decelerationSet);
   
   errorCode = setExecute(1);
   if (errorCode) {


### PR DESCRIPTION
Use correct deceleration at motor record JOG after use of different deceleration i.e. at homing.
