### PR TITLE
Moved asynDriver.h out of the extern block

### DIFF
--- a/devEcmcSup/com/ecmcOctetIF.h
+++ b/devEcmcSup/com/ecmcOctetIF.h
@@ -16,13 +16,12 @@
 # define __STDC_FORMAT_MACROS // To have PRIx64
 # include <inttypes.h>
 
+/* asynPrintf() */
+# include "asynDriver.h"
+
 # ifdef __cplusplus
 extern "C" {
 # endif /* ifdef __cplusplus */
-
-
-/* asynPrintf() */
-# include "asynDriver.h"
 
 # ifndef ASYN_TRACE_INFO
 #  define ASYN_TRACE_INFO      0x0040


### PR DESCRIPTION
This is necessary due to changes in EPICS base between 7.0.6 and 7.0.6.1. See
https://github.com/epics-base/epics-base/commit/cb8c7998b62701a849a6fa9c299cc1613f66a627
and the changes to epicsTime.h in particular.